### PR TITLE
Update to use new container driver API

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -298,6 +298,6 @@ module.exports = {
      * Shutdown Driver
      */
     shutdown: async () => {
-
+        clearTimeout(this._initialCheckTimeout)
     }
 }


### PR DESCRIPTION
This updates the docker driver to the new driver API introduced by flowforge/flowforge#437

 - API changed to support stopping a project without clearing its resources (ie 'suspended' state)
    - at the moment, this is identical to removing (deleting) the project as we may need to restart the project using a different stack (ie container image). This is a potential optimisation where we don't remove the container after stopping - and check on restart whether the Stack has changed and if so, then do the remove/create/start on the new image.
 - Modified the initial check of running containers to do the absolute minimum database query to list projects. Only resumes projects that are not 'suspended'. Also now handles a project container that exists but has been stopped (these weren't showing up in the default `listContainers` response)