### PR TITLE
Add FORGE_BROKER_* credentials to launcher env

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -45,6 +45,11 @@ const createContainer = async (project, domain) => {
     // httpStorage settings
     contOptions.Env.push(`FORGE_PROJECT_ID=${project.id}`)
     contOptions.Env.push(`FORGE_PROJECT_TOKEN=${authTokens.token}`)
+    // broker settings
+    if (authTokens.broker) {
+        contOptions.Env.push(`FORGE_BROKER_USERNAME=${authTokens.broker.username}`)
+        contOptions.Env.push(`FORGE_BROKER_PASSWORD=${authTokens.broker.password}`)
+    }
 
     const credentialSecret = await project.getSetting('credentialSecret')
     if (credentialSecret) {

--- a/docker.js
+++ b/docker.js
@@ -47,6 +47,7 @@ const createContainer = async (project, domain) => {
     contOptions.Env.push(`FORGE_PROJECT_TOKEN=${authTokens.token}`)
     // broker settings
     if (authTokens.broker) {
+        contOptions.Env.push(`FORGE_BROKER_URL=${authTokens.broker.url}`)
         contOptions.Env.push(`FORGE_BROKER_USERNAME=${authTokens.broker.username}`)
         contOptions.Env.push(`FORGE_BROKER_PASSWORD=${authTokens.broker.password}`)
     }


### PR DESCRIPTION
Part of https://github.com/flowforge/flowforge/pull/706

This passes through the broker credentials to the launcher - if they are set.